### PR TITLE
Updating the groupId of the package.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.rpsl4j</groupId>
+  <groupId>org.rpsl4j</groupId>
   <artifactId>rpsl4j-parser</artifactId>
   <version>1.81-SNAPSHOT</version>
   <packaging>jar</packaging>


### PR DESCRIPTION
rpsl4j.org has been acquired and as such can be used as the groupId of
the package on oss.sonatype.org.
